### PR TITLE
setting l1 base fee on l3 based on l2 arbgasinfo

### DIFF
--- a/scripts/l3Configuration.ts
+++ b/scripts/l3Configuration.ts
@@ -99,17 +99,18 @@ async function main() {
         console.log("Getting L1 base fee estimate")
         const l1BaseFeeEstimate = await ArbOGasInfo.getL1BaseFeeEstimate();
         console.log(`L1 Base Fee estimate on L2 is ${l1BaseFeeEstimate.toNumber()}`)
-
+        const l2Basefee = await L2Provider.getGasPrice();
+        const totalGasPrice = await l1BaseFeeEstimate.add(l2Basefee);
         console.log("Setting L1 base fee estimate on L3 ")
-        const tx4 = await ArbOwner.setL1PricePerUnit(l1BaseFeeEstimate);
+        const tx4 = await ArbOwner.setL1PricePerUnit(totalGasPrice);
     
         // Wait for the transaction to be mined
         const receipt4 = await tx4.wait();
         console.log(`L1 base fee estimate is set on the block number ${await receipt4.blockNumber} on the appchain`)
 
         // Check the status of the transaction: 1 is successful, 0 is failure
-        if (receipt2.status === 0) {
-            throw new Error('network fee receiver Setting network fee receiver transaction failed');
+        if (receipt4.status === 0) {
+            throw new Error('Base Fee Setting failed');
         }
     
 


### PR DESCRIPTION
In this PR , we get the data of the current L1 base fee estimate on Arb goerli by calling ArbGasInfo precompile there, and then set it on the L3 ArbOwner.
The reason we're doing that is L1 basefee estimate is defaulted to 50 gwei and it takes time to get balanced and it'll overprice the txs for a while