### PR TITLE
add too long notification

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -128,7 +128,7 @@ async function main() {
         let tooLongNotification = ''
         if (depositCheckTime >= 6) {
           tooLongNotification =
-            "(It takes too long, did you change the config files? If you changed, you need delete ./config/My Arbitrum L3 Chain, since this chain data is for your last config file, if you didn't, pleasen ignore this msg.)"
+            "(It is taking a long time. Did you change the config files? If you did, you will need to delete ./config/My Arbitrum L3 Chain, since this chain data is for your last config file. If you didn't change the file, please ignore this message.)"
         }
         console.log(
           `Balance not changed yet. Waiting for another 30 seconds ⏰⏰⏰⏰⏰⏰ ${tooLongNotification}`

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -125,13 +125,13 @@ async function main() {
           )
           break
         }
-        let tooLongNotify = ''
+        let tooLongNotification = ''
         if (depositCheckTime >= 6) {
-          tooLongNotify =
-            "(It takes too long, did you change the config files? If you changed, you need delete ./config/My Arbitrum L3 Chain, since this chain data is for your last config file, if you didn't change, pleasen ignore this msg.)"
+          tooLongNotification =
+            "(It takes too long, did you change the config files? If you changed, you need delete ./config/My Arbitrum L3 Chain, since this chain data is for your last config file, if you didn't, pleasen ignore this msg.)"
         }
         console.log(
-          `Balance not changed yet. Waiting for another 30 seconds ⏰⏰⏰⏰⏰⏰ ${tooLongNotify}`
+          `Balance not changed yet. Waiting for another 30 seconds ⏰⏰⏰⏰⏰⏰ ${tooLongNotification}`
         )
         await delay(30 * 1000)
       }

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -112,10 +112,12 @@ async function main() {
       )
       const oldBalance = await L3Provider.getBalance(config.chainOwner)
       await ethDeposit(privateKey, L2_RPC_URL, L3_RPC_URL)
+      let depositCheckTime = 0
 
       // Waiting for 30 secs to be sure that ETH deposited is received on L3
       // Repeatedly check the balance until it changes by 1 Ether
       while (true) {
+        depositCheckTime++
         const newBalance = await L3Provider.getBalance(config.chainOwner)
         if (newBalance.sub(oldBalance).gte(ethers.utils.parseEther('0.4'))) {
           console.log(
@@ -123,8 +125,13 @@ async function main() {
           )
           break
         }
+        let tooLongNotify = ''
+        if (depositCheckTime >= 6) {
+          tooLongNotify =
+            "(It takes too long, did you change the config files? If you changed, you need delete ./config/My Arbitrum L3 Chain, since this chain data is for your last config file, if you didn't change, pleasen ignore this msg.)"
+        }
         console.log(
-          'Balance not changed yet. Waiting for another 30 seconds ⏰⏰⏰⏰⏰⏰'
+          `Balance not changed yet. Waiting for another 30 seconds ⏰⏰⏰⏰⏰⏰ ${tooLongNotify}`
         )
         await delay(30 * 1000)
       }

--- a/scripts/tokenBridgeDeployment.ts
+++ b/scripts/tokenBridgeDeployment.ts
@@ -21,7 +21,7 @@ import { ArbMulticall2__factory } from '../contracts/factories/ArbMulticall2__fa
 import { L3Config } from './l3ConfigType'
 import fs from 'fs'
 
-import { defaultRunTimeState, L2, L3, RuntimeState } from './runTimeState'
+import { L2, L3, RuntimeState } from './runTimeState'
 
 // WETH address already deployed on L2
 // It's Arb Goerli currently. Need to change this when moving to Arb one


### PR DESCRIPTION
Since an [user](https://discord.com/channels/585084330037084172/1116812793606328340/1134302855973584907) from discord said he/she is waiting eth deposit for more than 1 hour due to different chain config -> chain state matching, we can add a notification for this.