### PR TITLE
fix: update urls in output info file

### DIFF
--- a/scripts/tokenBridgeDeployment.ts
+++ b/scripts/tokenBridgeDeployment.ts
@@ -586,8 +586,8 @@ export async function tokenBridgeDeployment(
       chainName: config.chainName,
       chainId: config.chainId,
       parentChainId: 421613,
-      rpcUrl: 'http://localhost/:8449',
-      explorerUrl: 'http://localhost:4000/',
+      rpcUrl: 'http://localhost:8449',
+      explorerUrl: 'http://localhost:4000',
     },
     coreContracts: {
       rollup: config.rollup,


### PR DESCRIPTION
There was an error in the `rpcUrl` property where there was a slash before the colon