### PR TITLE
fix amount setting

### DIFF
--- a/scripts/chargeEthOrErc20.ts
+++ b/scripts/chargeEthOrErc20.ts
@@ -60,19 +60,21 @@ async function main() {
     )
     // deposit 0.4 ETH
     const tx = await contract.depositEth({
-      value: ethers.utils.parseEther('0.4'),
+      value: ethers.utils.parseEther(amount),
     })
     console.log('Transaction hash on parent chain: ', tx.hash)
     await tx.wait()
     console.log('Transaction has been mined')
-    console.log('0.4 ETHs are deposited to your account')
+    console.log(amount + ' ETHs are deposited to your account')
   } else {
     const nativeTokenContract = ERC20__factory.connect(nativeToken, l2Provider)
     const decimals = await nativeTokenContract.decimals()
-    if(decimals !== 18) {
-      throw new Error("We currently only support 18 decimals token")
+    if (decimals !== 18) {
+      throw new Error('We currently only support 18 decimals token')
     }
-    tx = await erc20Inbox.depositERC20(ethers.utils.parseUnits(amount, decimals))
+    tx = await erc20Inbox.depositERC20(
+      ethers.utils.parseUnits(amount, decimals)
+    )
     console.log('Transaction hash on parent chain: ', tx.hash)
     await tx.wait()
     console.log('Transaction has been mined')


### PR DESCRIPTION
We force user to use `AMOUNT` as env var, but it doesn't use it when deposit ethers, so this pr also let the script use `AMOUNT` for ethers deposit.