### PR TITLE
Mount das-data volume in local dir

### DIFF
--- a/das-data/.gitignore
+++ b/das-data/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -94,10 +94,7 @@ services:
     volumes:
       - "./config:/home/user/.arbitrum"
       - "./das-server.sh:/das-server.sh"
-      - "das-data:/home/user/das-data"
+      - "./das-data:/home/user/das-data"
     ports:
       - "9876:9876"
       - "9877:9877"
-
-volumes:
-  das-data:


### PR DESCRIPTION
When using the current config, I get the following error (using Ubuntu on WSL) :
```
ERROR[02-09|08:27:18.535] Error running DAServer                   err="Cannot write pid file \"/home/user/das-data/LOCK\" error: open /home/user/das-data/LOCK: permission denied"
```

After that, the DAS container exits.

To solve this permission issue, this PR creates the das-data folder in the local structure and mounts that as the volume for `das-data`.