### PR TITLE
Docker-compose v2.24.6 compatibility

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./docker-compose/services/db.yml
       service: db
@@ -59,7 +62,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./docker-compose/services/stats.yml
       service: stats-db
@@ -67,6 +71,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./docker-compose/services/stats.yml
       service: stats

--- a/docker-compose/services/db.yml
+++ b/docker-compose/services/db.yml
@@ -12,9 +12,6 @@ services:
         chown -R 2000:2000 /var/lib/postgresql/data
 
   db:
-    depends_on:
-      db-init:
-        condition: service_completed_successfully
     image: postgres:14
     user: 2000:2000
     restart: always

--- a/docker-compose/services/stats.yml
+++ b/docker-compose/services/stats.yml
@@ -12,9 +12,6 @@ services:
         chown -R 2000:2000 /var/lib/postgresql/data
 
   stats-db:
-    depends_on:
-      stats-db-init:
-        condition: service_completed_successfully
     image: postgres:14
     user: 2000:2000
     restart: always
@@ -42,8 +39,6 @@ services:
     platform: linux/amd64
     restart: always
     container_name: 'stats'
-    depends_on:
-      - "stats-db"
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     env_file:


### PR DESCRIPTION
Docker-compose v2.24.6 introduced a breaking change:
> Services that have dependencies on other services cannot be used as a base. Therefore, any key that introduces a dependency on another service is incompatible with extends. The non-exhaustive list of such keys is: links, volumes_from, container mode (in ipc, pid, network_mode and net), service mode (in ipc, pid and network_mode), depends_on.

This PR resolves the issue by moving `depends_on` from base to extended service.