### PR TITLE
chore: Switch to Arbitrum-specific Docker image for Blockscout explorer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
     links:
       - db:database
     environment:
+        CHAIN_TYPE: "arbitrum"
         ETHEREUM_JSONRPC_HTTP_URL: http://nitro:8449/
         ETHEREUM_JSONRPC_TRACE_URL: http://nitro:8449/
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: "true"

--- a/docker-compose/services/backend.yml
+++ b/docker-compose/services/backend.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   backend:
-    image: blockscout/${DOCKER_REPO:-blockscout}:${DOCKER_TAG:-6.0.0}
+    image: blockscout/${DOCKER_REPO:-blockscout-arbitrum}:${DOCKER_TAG:-6.5.0}
     pull_policy: always
     restart: always
     stop_grace_period: 5m

--- a/docker-compose/services/db.yml
+++ b/docker-compose/services/db.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   db-init:
-    image: postgres:14
+    image: postgres:15
     volumes:
       - ./blockscout-db-data:/var/lib/postgresql/data
     entrypoint:
@@ -12,7 +12,7 @@ services:
         chown -R 2000:2000 /var/lib/postgresql/data
 
   db:
-    image: postgres:14
+    image: postgres:15
     user: 2000:2000
     restart: always
     container_name: 'db'

--- a/docker-compose/services/frontend.yml
+++ b/docker-compose/services/frontend.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   frontend:
-    image: ghcr.io/blockscout/frontend:${FRONTEND_DOCKER_TAG:-v1.21.2}
+    image: ghcr.io/blockscout/frontend:${FRONTEND_DOCKER_TAG:-v1.29.1}
     pull_policy: always
     platform: linux/amd64
     restart: always

--- a/docker-compose/services/stats.yml
+++ b/docker-compose/services/stats.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   stats-db-init:
-    image: postgres:14
+    image: postgres:15
     volumes:
       - ./stats-db-data:/var/lib/postgresql/data
     entrypoint:
@@ -12,7 +12,7 @@ services:
         chown -R 2000:2000 /var/lib/postgresql/data
 
   stats-db:
-    image: postgres:14
+    image: postgres:15
     user: 2000:2000
     restart: always
     container_name: 'stats-postgres'


### PR DESCRIPTION
Blockscout started to issue Arbitrum-specific Docker images into `blockscout-arbitrum` repository.
It added support parsing traces for Arbitrum at the moment. In the future, new features like indexing L1 <-> L2 messages will appear in that image.

Blockscout Frontend Docker image is changed by following compatibility matrix https://docs.blockscout.com/for-developers/information-and-settings/requirements/back-front-compatibility-matrix.

In addition, Postgres version is changed to V15.