### PR TITLE
Add dotenv to avoid network errors upon setup

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,6 @@
+# Your deployer wallet private key
+PRIVATE_KEY='0xXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+# Parent chain RPC endpoint
+L2_RPC_URL='https://sepolia-rollup.arbitrum.io/rpc'
+# Child chain RPC endpoint
+L3_RPC_URL='http://localhost:8449'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Once you’ve downloaded both config files from the [Orbit Deployment UI](https:
 
 1. Clone the https://github.com/OffchainLabs/orbit-setup-script repository, and run `yarn install`. Then, move both the `nodeConfig.json` and `orbitSetupScriptConfig.json` files into the `config` directory within the cloned repository
 2. Launch Docker, and in the base directory, run `docker-compose up -d`. This will launch the node with a public RPC reachable at http://localhost:8449/  and a corresponding BlockScout explorer instance, viewable at http://localhost/
-3. Then, add the private key for the wallet you used to deploy the rollup contracts earlier in the following command, and run it: `PRIVATE_KEY="0xYourPrivateKey" L2_RPC_URL="<https://sepolia-rollup.arbitrum.io/rpc>" L3_RPC_URL="http://localhost:8449" yarn run setup`
-4. The Orbit chain is now up. You can find all information about the newly deployed chain in the `outputInfo.json` file which is created in the main directory of script folder
-5. Optionally, to track logs, run the following command within the base directory: `docker-compose logs -f nitro`
+3. Add the private key for the wallet you used to deploy the Rollup contracts earlier and the RPC endpoints you intend to use for your L2 and L3 in a `.env` file (you can find a `.env-example` file at the root of this repo). 
+4. Run `yarn run setup`
+5. The Orbit chain is now up. You can find all information about the newly deployed chain in the `outputInfo.json` file which is created in the main directory of script folder
+6. Optionally, to track logs, run the following command within the base directory: `docker-compose logs -f nitro`

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@arbitrum/nitro-contracts": "^1.1.1",
     "@arbitrum/orbit-sdk": "^0.8.0",
     "@arbitrum/token-bridge-contracts": "^1.2.1",
+    "dotenv": "^16.4.5",
     "viem": "^1.20.0"
   },
   "devDependencies": {

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -6,6 +6,9 @@ import { createERC20Bridge } from './createTokenBridge'
 import { l3Configuration } from './l3Configuration'
 import { defaultRunTimeState, RuntimeState } from './runTimeState'
 import { transferOwner } from './transferOwnership'
+import * as dotenv from 'dotenv'
+dotenv.config()
+
 // Delay function
 function delay(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,6 +1731,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
 elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz"


### PR DESCRIPTION
### Problem:
 In its current state, this repo lets users launch the setup script by invoking `./scripts/setup.ts` with `PRIVATE_KEY="0xYourPrivateKey" L2_RPC_URL="<https://sepolia-rollup.arbitrum.io/rpc>" L3_RPC_URL="http://localhost:8449" yarn run setup`.
This can lead to errors if the user mistypes the `L2_RPC_URL` or `L3_RPC_URL` (my scripts failed even with the correct URLs).

This PR is an attempt at solving the problem by adding a `.env-example` file and a `dotenv` integration.