### PR TITLE
add smart contract verifier and eth amount for bridging

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,6 +93,13 @@ services:
       - "./config:/home/user/.arbitrum"
     command: --conf.file /home/user/.arbitrum/nodeConfig.json
 
+  smart-contract-verifier:
+    extends:
+      file: ./docker-compose/services/smart-contract-verifier.yml
+      service: smart-contract-verifier
+    ports:
+      - "127.0.0.1:8050:8050"
+
   das-server:
     image: offchainlabs/nitro-node:v3.2.1-d81324d
     entrypoint: [ "/bin/bash", "/das-server.sh" ]

--- a/scripts/chargeEthOrErc20.ts
+++ b/scripts/chargeEthOrErc20.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers'
+import { BigNumber, ethers } from 'ethers'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 import fs from 'fs'
 
@@ -58,14 +58,13 @@ async function main() {
       depositEthInterface,
       l2Signer
     )
-    // deposit 0.4 ETH
     const tx = await contract.depositEth({
-      value: ethers.utils.parseEther('0.4'),
+      value: ethers.BigNumber.from(ethers.utils.parseEther(amount)),
     })
     console.log('Transaction hash on parent chain: ', tx.hash)
     await tx.wait()
     console.log('Transaction has been mined')
-    console.log('0.4 ETHs are deposited to your account')
+    console.log(amount + ' ETHs are deposited to your account')
   } else {
     const nativeTokenContract = ERC20__factory.connect(nativeToken, l2Provider)
     const decimals = await nativeTokenContract.decimals()


### PR DESCRIPTION
### PR Description

- **Fixed ETH Bridge Amount**: Updated the ETH bridge amount to be configurable via an environment variable, similar to the ERC20 bridge. Previously, this value was hardcoded to `0.4 ETH`.
  
- **Added Smart Contract Verifier to Docker Compose**: Included the `smart-contract-verifier` image in the `docker-compose.yaml` file. The verifier was integrated in the code but not operational due to its absence in the compose file.

This PR ensures both the ETH bridge and verifier run as expected with configurable and complete setup.